### PR TITLE
Fix footer url and copyright

### DIFF
--- a/_partials/footer.ejs
+++ b/_partials/footer.ejs
@@ -6,7 +6,7 @@
             </div>
             <div class="mdl-cell mdl-cell--2-col mdl-cell--12-col-tablet footer-links">
                 <ul class="footer-links">
-                    <li> <a class="" href="https://wwww.angular.io">Learn Angular</a> </li>
+                    <li> <a class="" href="https://angular.io">Learn Angular</a> </li>
                 </ul>
             </div>
             <div class="mdl-cell mdl-cell--9-col">

--- a/_partials/footer.ejs
+++ b/_partials/footer.ejs
@@ -10,7 +10,7 @@
                 </ul>
             </div>
             <div class="mdl-cell mdl-cell--9-col">
-                <p class="mdl-typography--font-light power-text"> Powered by Google ©2010-2016. Code licensed under an <a href="/license.html">MIT-style License</a>. Documentation licensed under <a href="http://creativecommons.org/licenses/by/4.0/">CC BY 4.0</a>.</p>
+                <p class="mdl-typography--font-light power-text"> Powered by Google ©2010-2017. Code licensed under an <a href="/license.html">MIT-style License</a>. Documentation licensed under <a href="http://creativecommons.org/licenses/by/4.0/">CC BY 4.0</a>.</p>
             </div>
         </div>
     </div>


### PR DESCRIPTION
Fix the URL for the "Learn Angular" link and update the copyright date to 2017.